### PR TITLE
Active User Small issue with active user also showing up in requests

### DIFF
--- a/src/apps/editor/components/molecules/User/User.tsx
+++ b/src/apps/editor/components/molecules/User/User.tsx
@@ -56,7 +56,7 @@ export default function User(props: {
 				onClick={() => (props.hideAction ? {} : setShowManageUser((prev) => !prev))}
 				disabled={unauthorized}
 				hideAction={props.hideAction}
-				isCurrent={currentLoggedInUser}
+				isCurrent={currentLoggedInUser && !props.hideAction}
 			>
 				<S.UserHeader>
 					<Avatar owner={userProfile} dimensions={{ wrapper: 23.5, icon: 15 }} callback={null} />


### PR DESCRIPTION
Before - 

<img width="1915" height="969" alt="Screenshot 2025-09-02 at 7 37 07 PM" src="https://github.com/user-attachments/assets/63179c3e-ce40-493a-a7db-1e1a5f6ba927" />

After - 

<img width="1915" height="969" alt="Screenshot 2025-09-02 at 7 36 43 PM" src="https://github.com/user-attachments/assets/f8d14499-dfed-4a33-b3c1-949cf26d97d2" />
