### PR TITLE
changes to url for showing name of category and not id

### DIFF
--- a/src/apps/engine/builder/base/content/index.tsx
+++ b/src/apps/engine/builder/base/content/index.tsx
@@ -13,7 +13,7 @@ export default function Content(props: any) {
 				<Routes>
 					<Route path=":portalId/post/:postId" element={<Page />} />
 					<Route path=":portalId/feed/:pageId" element={<Page />} />
-					<Route path=":portalId/feed/category/:category" element={<Page />} />
+					<Route path=":portalId/feed/category/:categoryName" element={<Page />} />
 					<Route path=":portalId/feed/tag/:tag" element={<Page />} />
 					<Route path=":portalId/feed/date/:year/:month" element={<Page />} />
 					<Route path=":portalId/feed/network/:network" element={<Page />} />
@@ -25,7 +25,7 @@ export default function Content(props: any) {
 
 					<Route path="post/:postId" element={<Page />} />
 					<Route path="feed/:pageId" element={<Page />} />
-					<Route path="feed/category/:category" element={<Page />} />
+					<Route path="feed/category/:categoryName" element={<Page />} />
 					<Route path="feed/tag/:tag" element={<Page />} />
 					<Route path="feed/date/:year/:month" element={<Page />} />
 					<Route path="feed/network/:network" element={<Page />} />

--- a/src/apps/engine/builder/base/navigation/index.tsx
+++ b/src/apps/engine/builder/base/navigation/index.tsx
@@ -38,7 +38,7 @@ export default function Navigation(props: any) {
 					onPointerEnter={() => (entry.children && entry.children.length > 0 ? setShowMenu(true) : {})}
 					onPointerLeave={() => setShowMenu(false)}
 				>
-					<NavLink to={getRedirect(`feed/category/${entry.id}`)}>
+					<NavLink to={getRedirect(`feed/category/${entry.name}`)} state={{ categoryId: entry.id }}>
 						{entry.icon && (
 							<S.Icon>
 								<ReactSVG src={`/img/icons/${entry.Icon}.svg`} />
@@ -55,7 +55,7 @@ export default function Navigation(props: any) {
 						<S.NavigationEntryMenu $layout={layout}>
 							{entry.children.map((entry: any, key: any) => {
 								return (
-									<NavLink to={getRedirect(`feed/category/${entry.id}`)} key={key}>
+									<NavLink to={getRedirect(`feed/category/${entry.name}`)} state={{ categoryId: entry.id }} key={key}>
 										<S.NavigationSubEntry>{entry.name}</S.NavigationSubEntry>
 									</NavLink>
 								);

--- a/src/apps/engine/builder/blocks/feed/postPreview/default/index.tsx
+++ b/src/apps/engine/builder/blocks/feed/postPreview/default/index.tsx
@@ -67,7 +67,11 @@ export default function PostPreview_Default(props: any) {
 					post?.metadata?.categories?.map((category: any, index: number) => {
 						return (
 							<React.Fragment key={index}>
-								<NavLink to={getRedirect(`feed/category/${category.id}`)}>
+								<NavLink
+									to={getRedirect(`feed/category/${category.name}`)}
+									state={{ categoryId: category.id }}
+									key={category.id}
+								>
 									<S.Category>{category.name}</S.Category>
 								</NavLink>
 								{index < post.metadata.categories.length - 1 && <>,&nbsp;</>}

--- a/src/apps/engine/builder/blocks/feed/postPreview/journal/index.tsx
+++ b/src/apps/engine/builder/blocks/feed/postPreview/journal/index.tsx
@@ -72,7 +72,7 @@ export default function PostPreview_Journal(props: any) {
 					post?.metadata?.categories?.map((category: any, index: number) => {
 						return (
 							<React.Fragment key={index}>
-								<NavLink to={getRedirect(`feed/category/${category.id}`)}>
+								<NavLink to={getRedirect(`feed/category/${category.name}`)} state={{ categoryId: category.id }}>
 									<S.Category>{category.name}</S.Category>
 								</NavLink>
 								{index < post.metadata.categories.length - 1 && <>,&nbsp;</>}

--- a/src/apps/engine/builder/blocks/feed/postPreview/minimal/index.tsx
+++ b/src/apps/engine/builder/blocks/feed/postPreview/minimal/index.tsx
@@ -46,7 +46,7 @@ export default function PostPreview_Minimal(props: any) {
 					post?.metadata?.categories?.map((category: any, index: number) => {
 						return (
 							<React.Fragment key={index}>
-								<NavLink to={getRedirect(`feed/category/${category.id}`)}>
+								<NavLink to={getRedirect(`feed/category/${category.name}`)} state={{ categoryId: category.id }}>
 									<S.Category>{category.name}</S.Category>
 								</NavLink>
 								{index < post.metadata.categories.length - 1 && <>,&nbsp;</>}

--- a/src/apps/engine/views/Category/index.tsx
+++ b/src/apps/engine/views/Category/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 import { PostList } from 'viewer/components/organisms/PostList';
 import { usePortalProvider } from 'viewer/providers/PortalProvider';
@@ -12,8 +12,8 @@ import { scrollTo } from 'helpers/window';
 import * as S from './styles';
 
 export default function Category() {
-	const { categoryId } = useParams<{ categoryId?: string }>();
-
+	const location = useLocation();
+	const categoryId = (location.state as { categoryId?: string })?.categoryId;
 	const portalProvider = usePortalProvider();
 
 	const [currentCategory, setCurrentCategory] = React.useState<PortalCategoryType | null>(null);


### PR DESCRIPTION
in the engine ( partially covers #195 )

For category URLs on the Engine, we should improve the slug - right now there's some unique id there? e.g. https://permaweb-journal.arweave.net/#/feed/category/1758929204828

this would change to https://permaweb-journal.arweave.net/#/feed/category/AO
