### PR TITLE
Category ID To Category Name

### DIFF
--- a/src/apps/engine/builder/base/navigation/index.tsx
+++ b/src/apps/engine/builder/base/navigation/index.tsx
@@ -38,7 +38,7 @@ export default function Navigation(props: any) {
 					onPointerEnter={() => (entry.children && entry.children.length > 0 ? setShowMenu(true) : {})}
 					onPointerLeave={() => setShowMenu(false)}
 				>
-					<NavLink to={getRedirect(`feed/category/${entry.id}`)}>
+					<NavLink to={getRedirect(`feed/category/${entry.name}`)}>
 						{entry.icon && (
 							<S.Icon>
 								<ReactSVG src={`/img/icons/${entry.Icon}.svg`} />
@@ -55,7 +55,7 @@ export default function Navigation(props: any) {
 						<S.NavigationEntryMenu $layout={layout}>
 							{entry.children.map((entry: any, key: any) => {
 								return (
-									<NavLink to={getRedirect(`feed/category/${entry.id}`)} key={key}>
+									<NavLink to={getRedirect(`feed/category/${entry.name}`)} key={key}>
 										<S.NavigationSubEntry>{entry.name}</S.NavigationSubEntry>
 									</NavLink>
 								);

--- a/src/apps/engine/builder/blocks/feed/postPreview/default/index.tsx
+++ b/src/apps/engine/builder/blocks/feed/postPreview/default/index.tsx
@@ -67,7 +67,7 @@ export default function PostPreview_Default(props: any) {
 					post?.metadata?.categories?.map((category: any, index: number) => {
 						return (
 							<React.Fragment key={index}>
-								<NavLink to={getRedirect(`feed/category/${category.id}`)}>
+								<NavLink to={getRedirect(`feed/category/${category.name}`)}>
 									<S.Category>{category.name}</S.Category>
 								</NavLink>
 								{index < post.metadata.categories.length - 1 && <>,&nbsp;</>}

--- a/src/apps/engine/builder/blocks/feed/postPreview/journal/index.tsx
+++ b/src/apps/engine/builder/blocks/feed/postPreview/journal/index.tsx
@@ -72,7 +72,7 @@ export default function PostPreview_Journal(props: any) {
 					post?.metadata?.categories?.map((category: any, index: number) => {
 						return (
 							<React.Fragment key={index}>
-								<NavLink to={getRedirect(`feed/category/${category.id}`)}>
+								<NavLink to={getRedirect(`feed/category/${category.name}`)}>
 									<S.Category>{category.name}</S.Category>
 								</NavLink>
 								{index < post.metadata.categories.length - 1 && <>,&nbsp;</>}

--- a/src/apps/engine/builder/blocks/feed/postPreview/minimal/index.tsx
+++ b/src/apps/engine/builder/blocks/feed/postPreview/minimal/index.tsx
@@ -46,7 +46,7 @@ export default function PostPreview_Minimal(props: any) {
 					post?.metadata?.categories?.map((category: any, index: number) => {
 						return (
 							<React.Fragment key={index}>
-								<NavLink to={getRedirect(`feed/category/${category.id}`)}>
+								<NavLink to={getRedirect(`feed/category/${category.name}`)}>
 									<S.Category>{category.name}</S.Category>
 								</NavLink>
 								{index < post.metadata.categories.length - 1 && <>,&nbsp;</>}


### PR DESCRIPTION
in the engine ( partially covers https://github.com/permaweb/portal/issues/195 )

For category URLs on the Engine, we should improve the slug - right now there's some unique id there? e.g. https://permaweb-journal.arweave.net/#/feed/category/1758929204828

this would change to https://permaweb-journal.arweave.net/#/feed/category/AO